### PR TITLE
Security fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ keystore.jks
 app/keystore.jks
 *.jks
 *.keystore
+keystore.properties
+local.properties

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,12 +21,22 @@ android {
         }
     }
 
+    // Load signing credentials from a git-ignored keystore.properties file
+    // (see keystore.properties.example). Never hardcode passwords in source.
+    val keystoreProperties = java.util.Properties()
+    val keystorePropertiesFile = rootProject.file("keystore.properties")
+    if (keystorePropertiesFile.exists()) {
+        keystoreProperties.load(java.io.FileInputStream(keystorePropertiesFile))
+    }
+
     signingConfigs {
-        create("release") {
-            storeFile = file("keystore.jks")
-            storePassword = "android"
-            keyAlias = "BugeStudioTeam"
-            keyPassword = "android"
+        if (keystoreProperties.containsKey("storePassword")) {
+            create("release") {
+                storeFile = file(keystoreProperties.getProperty("storeFile", "keystore.jks"))
+                storePassword = keystoreProperties.getProperty("storePassword")
+                keyAlias = keystoreProperties.getProperty("keyAlias")
+                keyPassword = keystoreProperties.getProperty("keyPassword")
+            }
         }
     }
 
@@ -37,7 +47,9 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            signingConfig = signingConfigs.getByName("release")
+            if (keystoreProperties.containsKey("storePassword")) {
+                signingConfig = signingConfigs.getByName("release")
+            }
         }
     }
     

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
 
     <application
         android:name=".util.AppGlobals"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:label="@string/app_name"

--- a/app/src/main/java/com/buge/appmanager/AppDetailActivity.kt
+++ b/app/src/main/java/com/buge/appmanager/AppDetailActivity.kt
@@ -551,12 +551,13 @@ class AppDetailActivity : BaseActivity() {
                 packageName
             }
 
-            val cacheDir = externalCacheDir
-            if (cacheDir == null) {
+            val baseCacheDir = externalCacheDir
+            if (baseCacheDir == null) {
                 Snackbar.make(binding.root, "Cannot access cache directory", Snackbar.LENGTH_SHORT).show()
                 return
             }
 
+            val cacheDir = File(baseCacheDir, "apk_cache").apply { mkdirs() }
             cleanupTempApkFiles(cacheDir)
 
             val safeAppName = appName

--- a/app/src/main/java/com/buge/appmanager/UpdateOptionsActivity.kt
+++ b/app/src/main/java/com/buge/appmanager/UpdateOptionsActivity.kt
@@ -43,7 +43,7 @@ class UpdateOptionsActivity : BaseActivity() {
         .connectTimeout(60, TimeUnit.SECONDS)
         .readTimeout(120, TimeUnit.SECONDS)
         .followRedirects(true)
-        .followSslRedirects(true)
+        .followSslRedirects(false)
         .build()
 
     private enum class UpdateMethod {

--- a/app/src/main/java/com/buge/appmanager/shizuku/ShizukuManager.kt
+++ b/app/src/main/java/com/buge/appmanager/shizuku/ShizukuManager.kt
@@ -13,6 +13,24 @@ object ShizukuManager {
     private const val TAG = "ShizukuManager"
     private const val REQUEST_CODE = 1001
 
+    // Security: Shell metacharacters that enable command injection.
+    // Any string interpolated into a shell command must pass this check.
+    private val SHELL_METACHARS = Regex("""[;|&`$()><\n\r\t'"]""")
+
+    /**
+     * Validates a string is safe for interpolation into a shell command.
+     * Package names from Android PackageManager are safe by design,
+     * but this provides defense-in-depth against future injection risks.
+     */
+    private fun isSafeShellArg(arg: String, label: String): Boolean {
+        return if (SHELL_METACHARS.containsMatchIn(arg)) {
+            Log.w(TAG, "Rejected unsafe $label containing shell metacharacters")
+            false
+        } else {
+            true
+        }
+    }
+
     fun isShizukuAvailable(): Boolean {
         return try {
             Shizuku.pingBinder()
@@ -96,6 +114,9 @@ object ShizukuManager {
     }
 
     suspend fun grantPermission(packageName: String, permission: String): ShizukuResult {
+        if (!isSafeShellArg(packageName, "packageName")) {
+            return ShizukuResult(false, "", "Unsafe package name")
+        }
         return when (permission) {
             "android.permission.WRITE_SETTINGS" -> {
                 executeCommand("appops set $packageName WRITE_SETTINGS allow")
@@ -116,6 +137,9 @@ object ShizukuManager {
     }
 
     suspend fun revokePermission(packageName: String, permission: String): ShizukuResult {
+        if (!isSafeShellArg(packageName, "packageName")) {
+            return ShizukuResult(false, "", "Unsafe package name")
+        }
         return when (permission) {
             "android.permission.WRITE_SETTINGS" -> {
                 executeCommand("appops set $packageName WRITE_SETTINGS deny")
@@ -224,22 +248,37 @@ object ShizukuManager {
     }
 
     suspend fun forceStop(packageName: String): ShizukuResult {
+        if (!isSafeShellArg(packageName, "packageName")) {
+            return ShizukuResult(false, "", "Unsafe package name")
+        }
         return executeCommand("am force-stop $packageName")
     }
 
     suspend fun clearData(packageName: String): ShizukuResult {
+        if (!isSafeShellArg(packageName, "packageName")) {
+            return ShizukuResult(false, "", "Unsafe package name")
+        }
         return executeCommand("pm clear $packageName")
     }
 
     suspend fun disableApp(packageName: String): ShizukuResult {
+        if (!isSafeShellArg(packageName, "packageName")) {
+            return ShizukuResult(false, "", "Unsafe package name")
+        }
         return executeCommand("pm disable-user --user 0 $packageName")
     }
 
     suspend fun enableApp(packageName: String): ShizukuResult {
+        if (!isSafeShellArg(packageName, "packageName")) {
+            return ShizukuResult(false, "", "Unsafe package name")
+        }
         return executeCommand("pm enable $packageName")
     }
 
     suspend fun uninstallApp(packageName: String): ShizukuResult {
+        if (!isSafeShellArg(packageName, "packageName")) {
+            return ShizukuResult(false, "", "Unsafe package name")
+        }
         return executeCommand("pm uninstall --user 0 $packageName")
     }
 }

--- a/app/src/main/java/com/buge/appmanager/ui/AppsFragment.kt
+++ b/app/src/main/java/com/buge/appmanager/ui/AppsFragment.kt
@@ -121,7 +121,7 @@ class AppsFragment : Fragment() {
                 }
                 tempZipFile = null
             }
-            val cacheDir = requireContext().externalCacheDir ?: requireContext().cacheDir
+            val cacheDir = File(requireContext().externalCacheDir ?: requireContext().cacheDir, "apk_cache")
             val files = cacheDir.listFiles { file -> file.name.endsWith(".zip") }
             files?.forEach { file ->
                 if (file.exists()) {
@@ -477,7 +477,7 @@ class AppsFragment : Fragment() {
         fileNameText: TextView
     ): File? = withContext(Dispatchers.IO) {
         try {
-            val cacheDir = requireContext().externalCacheDir ?: requireContext().cacheDir
+            val cacheDir = File(requireContext().externalCacheDir ?: requireContext().cacheDir, "apk_cache").apply { mkdirs() }
             val timestamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
             val zipFile = File(cacheDir, "apks_${timestamp}.zip")
 

--- a/app/src/main/java/com/buge/appmanager/util/LogManager.kt
+++ b/app/src/main/java/com/buge/appmanager/util/LogManager.kt
@@ -227,11 +227,22 @@ object LogManager {
 
     fun shizuku(context: Context, message: String, command: String? = null, result: String? = null) {
         val details = buildString {
-            command?.let { append("Command: $it\n") }
-            result?.let { append("Result: $it") }
+            command?.let { append("Command: ${redactCommand(it)}\n") }
+            result?.let { append("Result: ${redactResult(it)}") }
         }
         addLog(context, LogType.SHIZUKU, message, details.ifEmpty { null }, "Shizuku")
-        Log.d(logTag, "[SHIZUKU] $message${command?.let { " - $it" } ?: ""}")
+        Log.d(logTag, "[SHIZUKU] $message${command?.let { " - ${redactCommand(it)}" } ?: ""}")
+    }
+
+    private fun redactCommand(cmd: String): String {
+        // Redact package names and paths from shell commands to avoid
+        // leaking user app usage data in logs.
+        return cmd.replace(Regex("""\b[a-z][a-z0-9_.]*(\.[a-z][a-z0-9_.]*){2,}\b"""), "***")
+    }
+
+    private fun redactResult(result: String): String {
+        if (result.length > 500) return result.take(500) + "..."
+        return result
     }
 
     fun activity(context: Context, message: String, activityName: String, details: String? = null) {

--- a/app/src/main/java/com/buge/appmanager/util/PreferencesManager.kt
+++ b/app/src/main/java/com/buge/appmanager/util/PreferencesManager.kt
@@ -134,8 +134,21 @@ object PreferencesManager {
         return getPreferences(context).getBoolean(HIDE_NAV_LABELS_KEY, false)
     }
 
+    // Security: Only allow alphanumeric, dots, dashes, underscores, and spaces.
+    // Shell metacharacters are rejected to prevent command injection in UpdateHelper.
+    private val INSTALLER_NAME_REGEX = Regex("""^[a-zA-Z0-9._\- ]*$""")
+
     fun setInstallerName(context: Context, name: String) {
-        getPreferences(context).edit().putString(INSTALLER_NAME_KEY, name).apply()
+        val trimmed = name.trim()
+        if (trimmed.isEmpty()) {
+            getPreferences(context).edit().putString(INSTALLER_NAME_KEY, "").apply()
+            return
+        }
+        if (!INSTALLER_NAME_REGEX.matches(trimmed)) {
+            android.util.Log.w("PreferencesManager", "Rejected unsafe installer name: $trimmed")
+            return
+        }
+        getPreferences(context).edit().putString(INSTALLER_NAME_KEY, trimmed).apply()
     }
 
     fun getInstallerName(context: Context): String {

--- a/app/src/main/java/com/buge/appmanager/util/UpdateChecker.kt
+++ b/app/src/main/java/com/buge/appmanager/util/UpdateChecker.kt
@@ -27,6 +27,7 @@ object UpdateChecker {
     private val client = OkHttpClient.Builder()
         .connectTimeout(10, TimeUnit.SECONDS)
         .readTimeout(10, TimeUnit.SECONDS)
+        .followSslRedirects(false)
         .build()
 
     data class ReleaseInfo(

--- a/app/src/main/java/com/buge/appmanager/util/UpdateHelper.kt
+++ b/app/src/main/java/com/buge/appmanager/util/UpdateHelper.kt
@@ -21,7 +21,7 @@ object UpdateHelper {
         .connectTimeout(60, TimeUnit.SECONDS)
         .readTimeout(120, TimeUnit.SECONDS)
         .followRedirects(true)
-        .followSslRedirects(true)
+        .followSslRedirects(false)
         .build()
 
     private var progressDialog: androidx.appcompat.app.AlertDialog? = null
@@ -106,6 +106,15 @@ object UpdateHelper {
 
                 if (header[0] == 0x50.toByte() && header[1] == 0x4B.toByte() &&
                     header[2] == 0x03.toByte() && header[3] == 0x04.toByte()) {
+                    // Verify this APK belongs to this app before installing
+                    val pm = context.packageManager
+                    val apkInfo = pm.getPackageArchiveInfo(apkFile.absolutePath, 0)
+                    if (apkInfo == null || apkInfo.packageName != context.packageName) {
+                        LogManager.error(context, "APK package mismatch",
+                            "Expected: ${context.packageName}, Got: ${apkInfo?.packageName ?: "null"}")
+                        apkFile.delete()
+                        return@withContext null
+                    }
                     LogManager.success(context, "APK downloaded", "Size: ${apkFile.length()}")
                     return@withContext apkFile
                 } else {
@@ -141,9 +150,21 @@ object UpdateHelper {
                     return@withContext
                 }
 
+                // Security: Validate installerName before interpolating into shell command.
+                // Only alphanumeric, dots, dashes, underscores, spaces are safe.
+                val safeName = if (installerName.isNotEmpty()) {
+                    if (installerName.matches(Regex("^[a-zA-Z0-9._\\- ]*$"))) {
+                        installerName
+                    } else {
+                        LogManager.warning(context, "Rejected unsafe installer name, installing without -i",
+                            installerName)
+                        ""
+                    }
+                } else ""
+
                 // Build install command with proper -i format
-                val installCmd = if (installerName.isNotEmpty()) {
-                    "pm install -r -d -t --user 0 -i \"$installerName\" $tempPath"
+                val installCmd = if (safeName.isNotEmpty()) {
+                    "pm install -r -d -t --user 0 -i \"$safeName\" $tempPath"
                 } else {
                     "pm install -r -d -t --user 0 $tempPath"
                 }
@@ -164,10 +185,10 @@ object UpdateHelper {
 
                 if (installResult.success) {
                     showToast(context, "Update installed successfully")
-                    LogManager.success(context, "Update installed", "Installer: $installerName")
+                    LogManager.success(context, "Update installed", "Installer: $safeName")
                 } else {
                     // Try without -i flag as fallback
-                    if (installerName.isNotEmpty()) {
+                    if (safeName.isNotEmpty()) {
                         LogManager.warning(context, "Install with -i failed, retrying without -i")
                         val retryCmd = "pm install -r -d -t --user 0 $tempPath"
                         val retryResult = ShizukuManager.executeCommand(retryCmd)

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -2,14 +2,14 @@
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <external-path
         name="downloads"
-        path="Download/" />
+        path="Download/BugeAppManager/" />
     <external-path
         name="external_files"
-        path="." />
+        path="Android/data/com.buge.appmanager/files/" />
     <cache-path
         name="cache"
-        path="." />
+        path="apk_cache/" />
     <external-cache-path
         name="external_cache"
-        path="." />
+        path="apk_cache/" />
 </paths>

--- a/keystore.properties.example
+++ b/keystore.properties.example
@@ -1,0 +1,8 @@
+# Release signing configuration
+# !! KEEP THIS FILE PRIVATE - DO NOT COMMIT !!
+# Copy this file to keystore.properties and fill in your values.
+
+storePassword=android
+keyPassword=android
+keyAlias=BugeStudioTeam
+storeFile=keystore.jks


### PR DESCRIPTION
## PR：修几个安全问题 / Security fixes

### 1. 签名密钥写死在代码里
`build.gradle.kts` 里 `storePassword = "android"`，`keystore.jks` 还在 git 历史，clone 就能拿到密钥打包恶意 APK
→ 改成读本地 `keystore.properties`，不加版本控制

**Hardcoded signing credentials** — passwords "android" in source, keystore in git history, anyone can sign fake APKs
→ Load from local `keystore.properties` (gitignored)

### 2. installerName 能注入 shell 命令
`UpdateHelper.kt` 把用户填的 installerName 直接拼到 shell 命令里，Shizuku 以 root 执行，塞个 `"; rm -rf; "` 就能跑
→ 存的时候拦特殊字符，用的时候再查一遍，ShizukuManager 所有方法也加了入参校验

**Shell injection via installerName** — user input goes straight into `sh -c` as root
→ Validated on write (PreferencesManager), on use (UpdateHelper), and all ShizukuManager methods got defensive checks

### 3. 下完 APK 不验证是谁的
只看 ZIP 文件头 PK 开头就放过，GitHub API 被改或者中间人塞个恶意 APK 直接装
→ 下完后查包名，不是 `com.buge.appmanager` 就删

**No APK identity check** — only checked ZIP magic bytes, no package name or signature verification
→ Verify package name with `getPackageArchiveInfo` after download

### 4. FileProvider 路径设太宽
`file_paths.xml` 三个 path="."，整个存储目录都能走 FileProvider
→ 缩到具体子目录，分享 APK/ZIP 的地方也改成写到子目录

**Overly broad FileProvider paths** — three path="." exposed entire external storage / cache
→ Narrowed paths, updated shareApk and shareZipFile to use apk_cache/ subdirectory

### 5. OkHttp 允许 HTTPS 降 HTTP
三个 OkHttpClient 都开着 followSslRedirects，中间人能把下载链降成 HTTP
→ 关了

**SSL redirect downgrade** — OkHttp clients allowed HTTPS→HTTP redirects, enabling MITM
→ Set followSslRedirects(false)

### 6. allowBackup 开着
adb backup 能拿走 SharedPreferences，配合 installerName 注入能扩大攻击面
→ 关掉

**Backup enabled** — SharedPreferences extractable via adb backup, enables the injection chain
→ Set allowBackup=false

### 7. 日志里记了完整 shell 命令
`LogManager.shizuku()` 把完整的 `pm grant xxx` 写进日志，包名和操作内容都暴露了
→ 包名用 `***` 代替，结果太长就截断

**Shell commands logged in plain text** — full Shizuku commands (with package names) persisted to logs
→ Redact package names, truncate long results